### PR TITLE
Test task do not depend on mock generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 include docker.env
-test: generateMocks
+test:
 	go test ./... 
 
 build: test


### PR DESCRIPTION
When running tests a lot of time is taken by mock generation, however, they are not required to be re-generated on each test run, especially when the interfaces do not change so often. When that happens, test will just fail by telling `X does not implement Y`, and at that time, we can re-generate mocks.

This PR just makes the `test` task independent of mocks generation.